### PR TITLE
es2/RawGL2ES2demo: Remove AWT dependency to allow running on a Raspbe… 

### DIFF
--- a/src/demos/es2/RawGL2ES2demo.java
+++ b/src/demos/es2/RawGL2ES2demo.java
@@ -32,24 +32,12 @@ import javax.media.opengl.GLAutoDrawable;
 import javax.media.opengl.GLEventListener;
 import javax.media.opengl.GLProfile;
 import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLContext;
 import com.jogamp.newt.opengl.GLWindow;
 
-import com.jogamp.opengl.util.GLArrayDataServer;
-import com.jogamp.opengl.util.glsl.ShaderCode;
-import com.jogamp.opengl.util.glsl.ShaderState;
-import com.jogamp.opengl.util.glsl.ShaderProgram;
 import com.jogamp.opengl.util.*;
 import com.jogamp.common.nio.Buffers;
 
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
-import java.nio.Buffer;
-
-import javax.swing.JFrame;
-import javax.media.opengl.*;
-import javax.media.opengl.awt.GLCanvas;
 
 /**
  * <pre>
@@ -226,13 +214,6 @@ static final String fragmentShader =
             return multiply(m, r);
         }
 
-    private void printMatrix(float[] m){
-        System.out.println(m[0]+" "+m[1]+" "+m[2]+" "+m[3]+"\n"+
-                           m[4]+" "+m[5]+" "+m[6]+" "+m[7]+"\n"+
-                           m[8]+" "+m[9]+" "+m[10]+" "+m[11]+"\n"+
-                           m[12]+" "+m[13]+" "+m[14]+" "+m[15]+"\n");
-    }
-
 /* Introducing the GL2ES2 demo
  *
  * How to render a triangle using 424 lines of code using the RAW
@@ -243,7 +224,6 @@ static final String fragmentShader =
  */
     private double theta=0;
     private double s=0;
-    private double c=0;
     
     private static int width=1920;
     private static int height=1080;
@@ -396,7 +376,6 @@ static final String fragmentShader =
         // Update variables used in animation
         theta += 0.08;
         s = Math.sin(theta);
-        c = Math.cos(theta);
 
         // Get gl
         GL2ES2 gl = drawable.getGL().getGL2ES2();


### PR DESCRIPTION
... Pi; Make syntax BeanShell compatible.
- Raspberry Pi: Removed dependency of com.jogamp.newt.awt.NewtCanvasAWT
              to allow running on -Djava.awt.headlessi=true systems,
              we can do this by using NEWT directly to open a window.
  
  You can run this demo on a Raspberry Pi
  using the JogAmp JOGL auto-build aggregate from 20 Aug 2012 and later:
  
  wget http://jogamp.org/deployment/archive/master/gluegen_577-joal_347-jogl_790-jocl_653/archive/jogamp-all-platforms.7z
  7z x jogamp-all-platforms.7z
  cd jogamp-all-platforms
  wget https://raw.github.com/xranby/jogl-demos/master/src/demos/es2/RawGL2ES2demo.java
  javac -cp jar/jogl-all.jar:jar/gluegen-rt.jar RawGL2ES2demo.java
  java -Dnativewindow.ws.name=jogamp.newt.driver.bcm.vc.iv -cp jar/jogl-all.jar:jar/gluegen-rt.jar:. RawGL2ES2demo
- Beanshell: removed final in function arguments
           and changed float array declaration
           to become BeanShell compatible.
  
  You can run this demo interpreted using Beanshell:
  
  wget http://www.beanshell.org/bsh-2.0b4.jar
  java -cp jar/jogl-all.jar:jar/gluegen-rt.jar:bsh-2.0b4.jar:. bsh.Interpreter RawGL2ES2demo.java
- Vertex and Fragment shaders: remove #version lines to make the shaders compile on more drivers.
