### PR TITLE
www/index.html: Remove Grand Canyon Demo & XTrans

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -184,59 +184,6 @@
                                     <tbody>
                                         <tr>
                                             <td valign="top">
-                                                <div align="left"><strong>Grand Canyon Demo</strong></div>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td valign="top" bgcolor="#ffffff">
-                                                <table border="0" cellpadding="5" cellspacing="1"
-                                                       width="100%">
-                                                    <tbody>
-                                                        <tr>
-                                                            <td width="25%"><br/>
-                                                            </td>
-                                                            <td width="45%"><strong>Description</strong>
-                                                            </td>
-                                                            <td width="5%"><br/>
-                                                            </td>
-                                                            <td width="25%"><strong>Requirements</strong>
-                                                            </td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td width="25%">
-                                                                <a href="http://java.sun.com/products/jfc/tsc/articles/jcanyon/jcanyon.jnlp">
-                                                                    <img src="jcanyon_sm.jpg" width="160" height="125" alt="Launch Grand Canyon demo"/>
-                                                                </a>
-                                                            </td>
-                                                            <td width="45%"> A flight simulator written in the Java programming language using the
-                                                                New I/O APIs and OpenGL to visualize a large terrain data set in real time. <a
-                                                                    href="http://java.sun.com/products/jfc/tsc/articles/jcanyon/">Related
-                                                                    article</a>, including source code, on the <a
-                                                                    href="http://java.sun.com/products/jfc/tsc/">Swing Connection</a>.
-                                                            </td>
-                                                            <td width="5%"><br/>
-                                                            </td>
-                                                            <td width="25%"> None</td>
-                                                        </tr>
-                                                    </tbody>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table border="0" cellpadding="5" cellspacing="1" width="100%">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <table border="0" cellpadding="5"
-                                       cellspacing="1" width="100%">
-                                    <tbody>
-                                        <tr>
-                                            <td valign="top">
                                                 <div align="left"><strong>Hardware Shadow
                                                         Mapping</strong></div>
                                             </td>
@@ -909,61 +856,6 @@
                                                             <td width="5%"><br/>
                                                             </td>
                                                             <td width="25%">Pbuffer support, ARB_vertex_program, ARB_fragment_program</td>
-                                                        </tr>
-                                                    </tbody>
-                                                </table>
-                                            </td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table border="0" cellpadding="5" cellspacing="1" width="100%">
-                    <tbody>
-                        <tr>
-                            <td>
-                                <table border="0" cellpadding="5"
-                                       cellspacing="1" width="100%">
-                                    <tbody>
-                                        <tr>
-                                            <td valign="top">
-                                                <div align="left"><strong>XTrans</strong></div>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td valign="top" bgcolor="#ffffff">
-                                                <table border="0" cellpadding="5" cellspacing="1"
-                                                       width="100%">
-                                                    <tbody>
-                                                        <tr>
-                                                            <td width="25%"><br/>
-                                                            </td>
-                                                            <td width="45%"><strong>Description</strong>
-                                                            </td>
-                                                            <td width="5%"><br/>
-                                                            </td>
-                                                            <td width="25%"><strong>Requirements</strong>
-                                                            </td>
-                                                        </tr>
-                                                        <tr>
-                                                            <td width="25%">
-                                                                <a href="http://jogamp.org/deployment/jogamp-current/jogl-demos/XTrans.jnlp">
-                                                                    <img src="xtrans_sm.jpg" width="160" height="130" alt="Launch XTrans demo"/>
-                                                                </a>
-                                                            </td>
-                                                            <td width="45%"> Illustrates another use of the <a
-                                                                    href="http://192.18.37.44/forums/index.php?topic=10813.0">Java2D/JOGL
-                                                                    interoperability bridge</a> to provide OpenGL-accelerated animated transitions for
-                                                                unmodified Swing components. Requires <a href="https://mustang.dev.java.net/">Java
-                                                                    SE 6 (Mustang)</a> build 53 or later.
-                                                            </td>
-                                                            <td width="5%"><br/>
-                                                            </td>
-                                                            <td width="25%"><a href="https://mustang.dev.java.net/">Java SE 6 (Mustang)</a> build 53
-                                                                or later
-                                                            </td>
                                                         </tr>
                                                     </tbody>
                                                 </table>


### PR DESCRIPTION
Grand Canyon Demo was hosted on the now offline java.sun.com server.

XTrans require the, disabled by default, Java2D opengl backend to be enabled.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
